### PR TITLE
[修正]投稿関連

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,7 +27,7 @@ body {
   background-color: #F9F9FA;
 }
 
-a {
+header a {
   color: black;
 }
 
@@ -62,7 +62,6 @@ a:hover {
 // ヘッダー
 header ul li a:hover {
   text-decoration: none;
-  color: black;
 }
 
 header {
@@ -207,9 +206,9 @@ textarea#error_solution {
 }
 
 // エラー詳細ページ
-.update-btn {
+.btn {
   text-align: center;
-  line-height: 36px;
+  line-height: 29px;
   width: 250px;
   height: 36px;
   background-color: #60AB9A;
@@ -222,9 +221,15 @@ textarea#error_solution {
   border: none;
 }
 
-.error-details a, .update-btn a, a:hover {
+.top .btn a, .top .btn a:hover, .error-details a, .error-details a:hover {
   text-decoration: none;
   color: #fff;
+}
+
+.error-btn {
+  display: flex;
+  width: 600px;
+  margin: 0 auto;
 }
 
 // 新規登録画面

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,6 +18,7 @@ class ErrorsController < ApplicationController
 
   def create
     @error = Error.new(error_params)
+    @error.mentor_id = current_mentor.id
     if @error.save
       flash[:notice] = "エラー対応を記録しました"
       redirect_to error_path(@error)
@@ -44,9 +45,13 @@ class ErrorsController < ApplicationController
 
   def destroy
     error = Error.find(params[:id])
+    if error.mentor_id = current_mentor.id
     error.destroy
     flash[:notice] = "エラー対応を削除しました"
-    redirect_to :root_path
+    redirect_to root_path
+    else
+      redirect_to error_path(error)
+    end
   end
 
   private

--- a/app/views/errors/confirm.html.erb
+++ b/app/views/errors/confirm.html.erb
@@ -43,17 +43,17 @@
         <td class="content-body"><%= @error.mentor_name %></td>
       </tr>
     </table>
+    <%= form_with model:@error, url:errors_path, method: :post, local:true do |f| %>
+      <%= f.hidden_field :title, value: @error.title %>
+      <%= f.hidden_field :learning_phase, value: @error.learning_phase %>
+      <%= f.hidden_field :used_technology_id, value: @error.used_technology_id %>
+      <%= f.hidden_field :detail, value: @error.detail %>
+      <%#= f.hidden_field :image, value: @image %>
+      <%= f.hidden_field :solution, value: @error.solution %>
+      <%= f.hidden_field :url, value: @error.url%>
+      <%= f.hidden_field :mentor_name, value: @error.mentor_name%>
+      <%= f.submit "投稿", class:"content-submit" %>
+      <%= link_to "内容を修正する", new_error_path, class:"btn" %>
+    <% end %>
   </div>
-  <%= form_with model:@error, url:errors_path, method: :post, local:true do |f| %>
-    <%= f.hidden_field :title, value: @error.title %>
-    <%= f.hidden_field :learning_phase, value: @error.learning_phase %>
-    <%= f.hidden_field :used_technology_id, value: @error.used_technology_id %>
-    <%= f.hidden_field :detail, value: @error.detail %>
-    <%#= f.hidden_field :image, value: @image %>
-    <%= f.hidden_field :solution, value: @error.solution %>
-    <%= f.hidden_field :url, value: @error.url%>
-    <%= f.hidden_field :mentor_name, value: @error.mentor_name%>
-    <%= f.submit "投稿", class:"content-submit" %>
-    <%= link_to "内容を修正する", new_error_path, class:"update-btn" %>
-  <% end %>
 </main>

--- a/app/views/errors/show.html.erb
+++ b/app/views/errors/show.html.erb
@@ -39,7 +39,12 @@
         <td class="content-body"><%= @error.mentor_name %></td>
       </tr>
     </table>
-    <%= link_to "編集", edit_error_path(@error), class:"update-btn" %>
+      <% if @error.mentor_id == current_mentor.id %>
+      <div class="error-btn">
+        <%= link_to "編集", edit_error_path(@error), class:"btn" %>
+        <%= link_to "削除する", error_path(@error), method: :delete, 'data-confirm' => "本当に消しますか？", class:"btn", style:"background-color: #D38493;" %>
+      </div>
+      <% end %>
   </div>
   <div class="error-comments">
     <%= form_with model:[@error, @comment], local: true do |f| %>

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -3,7 +3,7 @@
     <div class="top-title">
       <h1>エラー掲示板</h1>
     </div>
-    <div class="update-btn">
+    <div class="btn">
       <%= link_to "新規投稿", new_error_path %>
     </div>
     <table class="top-table">


### PR DESCRIPTION
- 投稿時、mentor.idを関連付けし投稿させる。
- 詳細画面にてログインしているmentorが投稿したerrorの場合、編集と削除ボタンを設置（レイアウトOK）
