### PR TITLE
[修正]deviseでの新規登録、ログイン時のエラー修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -333,29 +333,6 @@ textarea#error_solution {
   }
 }
 
-
-// .comment-form {
-//   width: 80%;
-//   margin: 7rem auto;
-//   textarea#error_comment_comment {
-//     width: 35rem;
-//     height: 10rem;
-//   }
-//   .comment-submit {
-//     width: 60px;
-//     height: 20px;
-//     line-height: 20px;
-//     background-color: #60AB9A;
-//     color: #fff;
-//     font-weight: bold;
-//     display: block;
-//     font-size: 1.4rem;
-//     border-radius: 100vh;
-//     border: none;
-//     margin: 2rem;
-//   }
-// }
-
 // 新規登録画面
 .sign {
   font-family: 'Noto Sans JP', sans-serif;
@@ -391,6 +368,7 @@ textarea#error_solution {
     border-radius: 3px;
     background-color: #F9F9FA;
   }
+
   .sign-btn {
     width: 150px;
     height: 30px;
@@ -399,7 +377,7 @@ textarea#error_solution {
     color: #fff;
     font-weight: bold;
     display: block;
-    margin: 0 auto 4rem;
+    margin: 2rem auto;
     font-size: 1.6rem;
     border-radius: 100vh;
     border: none;

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -12,10 +12,6 @@ class ErrorsController < ApplicationController
     @comment = ErrorComment.new
   end
 
-  # def confirm
-  #   @error = Error.new(error_params)
-  # end
-
   def create
     @error = Error.new(error_params)
     @error.mentor_id = current_mentor.id

--- a/app/views/mentors/registrations/new.html.erb
+++ b/app/views/mentors/registrations/new.html.erb
@@ -27,7 +27,7 @@
           <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
         </td>
       </tr>
-    </table>
-      <%= f.submit "登録する", class:"sign-btn" %>
+      <td colspan="2"><%= f.submit "新規登録する", class:"sign-btn" %></td>
     <% end %>
+    </table>
 </div>

--- a/app/views/mentors/sessions/new.html.erb
+++ b/app/views/mentors/sessions/new.html.erb
@@ -15,7 +15,7 @@
           <%= f.password_field :password, autocomplete: "new-password" %>
         </td>
       </tr>
-  </table>
-      <%= f.submit "ログインする", class:"sign-btn" %>
+      <td colspan="2"><%= f.submit "ログインする", class:"sign-btn" %></td>
     <% end %>
+  </table>
 </div>


### PR DESCRIPTION
新規登録、ログインが一回リロードしないとできないエラーが発生。
[原因]
レイアウトとして使用しているtableタグの閉じタグ外にdeviseのf.submitを記述していたため、エラーが起きていた。
中に記述し、tableやcssを調整し、解決。